### PR TITLE
[#11] Fix weak dylibs support

### DIFF
--- a/MachObfuscator.xcodeproj/project.pbxproj
+++ b/MachObfuscator.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		D41FCFDF2152F34D00BE3C7A /* CpuId_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41FCFDE2152F34D00BE3C7A /* CpuId_Tests.swift */; };
 		D41FCFE12152F53100BE3C7A /* URL+NibLoading_loadNib_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41FCFE02152F53100BE3C7A /* URL+NibLoading_loadNib_Tests.swift */; };
 		D41FCFE32152F67D00BE3C7A /* Trie+Parsing_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41FCFE22152F67D00BE3C7A /* Trie+Parsing_Tests.swift */; };
-		D41FCFE52152FA5700BE3C7A /* Mach+Replacing_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41FCFE42152FA5700BE3C7A /* Mach+Replacing_Tests.swift */; };
+		D41FCFE52152FA5700BE3C7A /* Mach+Replacing_importEntries_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41FCFE42152FA5700BE3C7A /* Mach+Replacing_importEntries_Tests.swift */; };
 		D41FCFE82152FAF400BE3C7A /* RealWordsMangler_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41FCFE72152FAF400BE3C7A /* RealWordsMangler_Tests.swift */; };
 		D41FCFEA2152FB1D00BE3C7A /* CaesarMangler_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41FCFE92152FB1D00BE3C7A /* CaesarMangler_Tests.swift */; };
 		D41FCFED2152FB8200BE3C7A /* Obfuscator_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41FCFEC2152FB8200BE3C7A /* Obfuscator_Tests.swift */; };
@@ -264,7 +264,7 @@
 		D41FCFDE2152F34D00BE3C7A /* CpuId_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CpuId_Tests.swift; sourceTree = "<group>"; };
 		D41FCFE02152F53100BE3C7A /* URL+NibLoading_loadNib_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+NibLoading_loadNib_Tests.swift"; sourceTree = "<group>"; };
 		D41FCFE22152F67D00BE3C7A /* Trie+Parsing_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Trie+Parsing_Tests.swift"; sourceTree = "<group>"; };
-		D41FCFE42152FA5700BE3C7A /* Mach+Replacing_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mach+Replacing_Tests.swift"; sourceTree = "<group>"; };
+		D41FCFE42152FA5700BE3C7A /* Mach+Replacing_importEntries_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mach+Replacing_importEntries_Tests.swift"; sourceTree = "<group>"; };
 		D41FCFE72152FAF400BE3C7A /* RealWordsMangler_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealWordsMangler_Tests.swift; sourceTree = "<group>"; };
 		D41FCFE92152FB1D00BE3C7A /* CaesarMangler_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaesarMangler_Tests.swift; sourceTree = "<group>"; };
 		D41FCFEC2152FB8200BE3C7A /* Obfuscator_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Obfuscator_Tests.swift; sourceTree = "<group>"; };
@@ -676,7 +676,7 @@
 				D481611921231CB3008671D8 /* Mach+Loading_MachoMac_Tests.swift */,
 				D48161782125699B008671D8 /* Mach+Parsing_FatIos_Tests.swift */,
 				D4816122212334B4008671D8 /* Mach+Parsing_MachoMac_Tests.swift */,
-				D41FCFE42152FA5700BE3C7A /* Mach+Replacing_Tests.swift */,
+				D41FCFE42152FA5700BE3C7A /* Mach+Replacing_importEntries_Tests.swift */,
 				D4C48E9321E2B5A700498A62 /* Image+updateMachs_Tests.swift */,
 			);
 			path = MachTests;
@@ -1096,7 +1096,7 @@
 				D4816069211C69A4008671D8 /* DependencyNodeLoader.swift in Sources */,
 				D412C67A214076A200AA9A07 /* Options.swift in Sources */,
 				D44D73A32119FB5700DE002B /* Range+Sugar_Tests.swift in Sources */,
-				D41FCFE52152FA5700BE3C7A /* Mach+Replacing_Tests.swift in Sources */,
+				D41FCFE52152FA5700BE3C7A /* Mach+Replacing_importEntries_Tests.swift in Sources */,
 				D48161792125699B008671D8 /* Mach+Parsing_FatIos_Tests.swift in Sources */,
 				D432EAE9213DE06900C2ADA0 /* Image+Savable.swift in Sources */,
 				D44D73812119E87300DE002B /* NibPlist+Loading_Tests.swift in Sources */,

--- a/MachObfuscatorTests/MachTests/Mach+Replacing_Tests.swift
+++ b/MachObfuscatorTests/MachTests/Mach+Replacing_Tests.swift
@@ -1,5 +1,0 @@
-import XCTest
-
-class Mach_Replacing_Tests: XCTestCase {
-    // TODO: test missing
-}

--- a/MachObfuscatorTests/MachTests/Mach+Replacing_importEntries_Tests.swift
+++ b/MachObfuscatorTests/MachTests/Mach+Replacing_importEntries_Tests.swift
@@ -137,6 +137,7 @@ private extension ObfuscationPaths {
     init(resolvedDylibMapPerImageURL: [URL: [String: URL]]) {
         self.init(obfuscableImages: [URL.machoMacExecutable, URL.sampleDylib],
                   unobfuscableDependencies: [],
+                  systemFrameworks: [],
                   resolvedDylibMapPerImageURL: resolvedDylibMapPerImageURL,
                   nibs: [])
     }

--- a/MachObfuscatorTests/MachTests/Mach+Replacing_importEntries_Tests.swift
+++ b/MachObfuscatorTests/MachTests/Mach+Replacing_importEntries_Tests.swift
@@ -1,0 +1,143 @@
+import XCTest
+
+class Mach_Replacing_importEntries_Tests: XCTestCase {
+
+    var sut: Image!
+    var firstImportEntry: ImportStackEntry!
+    var originalSymbolBytes: [UInt8]!
+    var randomSubstitutionBytes: [UInt8]!
+    var symbolDylib: String!
+
+    override func setUp() {
+        super.setUp()
+
+        sut = try! Image.load(url: URL.machoMacExecutable)
+        firstImportEntry = sut.machs[0].importStack![0]
+        originalSymbolBytes = firstImportEntry.symbol
+        randomSubstitutionBytes = originalSymbolBytes.randomSymbolSubstitution
+        symbolDylib = sut.machs[0].dylibs[firstImportEntry.dylibOrdinal - 1]
+    }
+
+    override func tearDown() {
+        sut = nil
+        firstImportEntry = nil
+        originalSymbolBytes = nil
+        randomSubstitutionBytes = nil
+        symbolDylib = nil
+
+        super.tearDown()
+    }
+
+    func test_shouldReplaceImportEntrySymbolWithObfuscationMap() {
+        // Given
+        let map = SymbolManglingMap(selectors: [:], classNames: [:], exportTrieObfuscationMap: [
+            URL.machoMacExecutable: [
+                sut.machs[0].cpu.asCpuId:
+                    (unobfuscated: Trie.empty,
+                     obfuscated: Trie.empty)],
+            URL.sampleDylib: [
+                sut.machs[0].cpu.asCpuId:
+                    (unobfuscated: Trie.with(labelBytes: originalSymbolBytes),
+                     obfuscated: Trie.with(labelBytes: randomSubstitutionBytes))],
+        ])
+        let paths = ObfuscationPaths(resolvedDylibMapPerImageURL:
+            [URL.machoMacExecutable:[symbolDylib: URL.sampleDylib]])
+
+        // When
+        sut.replaceSymbols(withMap: map, paths: paths)
+
+        // Then
+        let dataAtSymbolRange = sut.machs[0].data[firstImportEntry.symbolRange]
+        XCTAssertEqual(dataAtSymbolRange, Data(randomSubstitutionBytes))
+    }
+
+    func test_shouldNotReplaceImportEntrySymbol_whenObfuscationMapMissesSymbol() {
+        // Given
+        let map = SymbolManglingMap(selectors: [:], classNames: [:], exportTrieObfuscationMap: [
+            URL.machoMacExecutable: [
+                sut.machs[0].cpu.asCpuId:
+                    (unobfuscated: Trie.empty,
+                     obfuscated: Trie.empty)],
+            URL.sampleDylib: [
+                sut.machs[0].cpu.asCpuId:
+                    (unobfuscated: Trie.empty,
+                     obfuscated: Trie.empty)],
+            ])
+        let paths = ObfuscationPaths(resolvedDylibMapPerImageURL:
+            [URL.machoMacExecutable:[symbolDylib: URL.sampleDylib]])
+
+        // When
+        sut.replaceSymbols(withMap: map, paths: paths)
+
+        // Then
+        let dataAtSymbolRange = sut.machs[0].data[firstImportEntry.symbolRange]
+        XCTAssertEqual(dataAtSymbolRange, Data(originalSymbolBytes))
+    }
+
+    func test_shouldNotReplaceImportEntrySymbol_whenObfuscationMapMissesDylib() {
+        // Given
+        let map = SymbolManglingMap(selectors: [:], classNames: [:], exportTrieObfuscationMap: [
+            URL.machoMacExecutable: [
+                sut.machs[0].cpu.asCpuId:
+                    (unobfuscated: Trie.empty,
+                     obfuscated: Trie.empty)]]
+        )
+        let paths = ObfuscationPaths(resolvedDylibMapPerImageURL:
+            [URL.machoMacExecutable:[symbolDylib: URL.sampleDylib]])
+
+        // When
+        sut.replaceSymbols(withMap: map, paths: paths)
+
+        // Then
+        let dataAtSymbolRange = sut.machs[0].data[firstImportEntry.symbolRange]
+        XCTAssertEqual(dataAtSymbolRange, Data(originalSymbolBytes))
+    }
+
+    func test_shouldNotReplaceImportEntrySymbol_whenObfuscationPathDoesntContainResolverDylib() {
+        // Given
+        let map = SymbolManglingMap(selectors: [:], classNames: [:], exportTrieObfuscationMap: [
+            URL.machoMacExecutable: [
+                sut.machs[0].cpu.asCpuId:
+                    (unobfuscated: Trie.empty,
+                     obfuscated: Trie.empty)]]
+        )
+        let paths = ObfuscationPaths(resolvedDylibMapPerImageURL: [URL.machoMacExecutable: [:]])
+
+        // When
+        sut.replaceSymbols(withMap: map, paths: paths)
+
+        // Then
+        let dataAtSymbolRange = sut.machs[0].data[firstImportEntry.symbolRange]
+        XCTAssertEqual(dataAtSymbolRange, Data(originalSymbolBytes))
+    }
+}
+
+private extension Array where Element == UInt8 {
+    var randomSymbolSubstitution: [UInt8] {
+        return map { _ in UInt8.random(in: 0x20...0x7E) }
+    }
+}
+
+private extension Trie {
+    static let empty = Trie(exportsSymbol: false, labelRange: 0..<0, label: [], children: [])
+    static func with(labelBytes: [UInt8]) -> Trie {
+        return Trie(exportsSymbol: false,
+                    labelRange: 0..<0,
+                    label: labelBytes,
+                    children: [ Trie(exportsSymbol: true, labelRange: 0..<0, label: [], children: []) ])
+
+    }
+}
+
+private extension URL {
+    static let sampleDylib = URL(fileURLWithPath: "/tmp/lib7")
+}
+
+private extension ObfuscationPaths {
+    init(resolvedDylibMapPerImageURL: [URL: [String: URL]]) {
+        self.init(obfuscableImages: [URL.machoMacExecutable, URL.sampleDylib],
+                  unobfuscableDependencies: [],
+                  resolvedDylibMapPerImageURL: resolvedDylibMapPerImageURL,
+                  nibs: [])
+    }
+}


### PR DESCRIPTION
MachObfuscator detects weak dylib load-commands. Until now, it required the weak dylib to exist while obfuscating export-trie. This PR relaxates this requirement, so MachObfuscator doesn't quit with `fatalError`.