### PR TITLE
Nonzero exit on unknown arguments

### DIFF
--- a/MachObfuscator/Options/Options.swift
+++ b/MachObfuscator/Options/Options.swift
@@ -23,6 +23,7 @@ struct ObjcOptions {
 }
 
 struct Options {
+    var unknownOption = false
     var help = false
     var dryrun = false
     var quiet = false
@@ -193,7 +194,7 @@ extension Options {
                 analyzeDependencies = false
 
             case OptLongChars.unknownOption:
-                help = true
+                unknownOption = true
             default:
                 fatalError("Unexpected argument: \(option)")
             }

--- a/MachObfuscator/main.swift
+++ b/MachObfuscator/main.swift
@@ -2,9 +2,13 @@ import Foundation
 
 private func main() {
     let options = Options.fromCommandLine()
-    guard !options.help, let manglerType = options.manglerType, let appDirectoryOrFile = options.appDirectoryOrFile else {
+    guard !options.help, !options.unknownOption, let manglerType = options.manglerType, let appDirectoryOrFile = options.appDirectoryOrFile else {
         print(Options.usage)
-        return
+        if options.help {
+            return
+        } else {
+            exit(EXIT_FAILURE)
+        }
     }
 
     LOGGER = SoutLogger(options: options)


### PR DESCRIPTION
Requires #74 to be merged first due to changes in `main`

Nonzero exit code is important to be able to detect changes or wrong Obfuscator arguments in scripts, continuous integration etc.