### PR TITLE
Obfuscator should detect obfuscable files when absolute path contain dots

### DIFF
--- a/MachObfuscator/DependencyAnalysis/ObfuscableFilesFilter.swift
+++ b/MachObfuscator/DependencyAnalysis/ObfuscableFilesFilter.swift
@@ -49,7 +49,7 @@ extension ObfuscableFilesFilter {
 
     static func onlyFiles(in obfuscableDirectory: URL) -> ObfuscableFilesFilter {
         return ObfuscableFilesFilter { url in
-            obfuscableDirectory.contains(url)
+            obfuscableDirectory.standardizedFileURL.contains(url.standardizedFileURL)
         }
     }
 


### PR DESCRIPTION
Obfuscator should detect obfuscable files when absolute path contain dots (`.` or `..`)