### PR TITLE
Remove __unsafe_unretained, _Nullable, _Nonnull from header sources

### DIFF
--- a/MachObfuscator/HeadersParsing/String+objCMethodNames.swift
+++ b/MachObfuscator/HeadersParsing/String+objCMethodNames.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// Remove __unsafe_unretained, _Nullable, _Nonnull and their variations and arrays, eg. [_Nonnull]
+private let removedParameterAttributes = try! NSRegularExpression(pattern: "\\b(__unsafe_unretained)|(\\[?__?[nN]ullable\\]?)|(\\[?__?[nN]onnull\\]?)\\b")
 private let methodStartRegexp = try! NSRegularExpression(pattern: "^\\s*[-+]\\s*\\([^\\(\\)]*(\\([^\\(\\)]+\\)[^\\(\\)]*)*[^\\(\\)]*\\)", options: [.anchorsMatchLines])
 private let methodSuffixRegexp = try! NSRegularExpression(pattern: "\\s([A-Z_]+_[A-Z_]+\\b)|(__[a-z_]+\\b)", options: [])
 private let namedParameterRegexp = try! NSRegularExpression(pattern: "\\b(\\w+:)", options: [])
@@ -11,6 +13,7 @@ extension String {
     var objCMethodNames: [String] {
         let headerWithoutComments = withoutComments
         let allLines = headerWithoutComments.components(separatedBy: methodNameDelimiters)
+            .map { $0.withoutOccurences(of: removedParameterAttributes) }
         return allLines.compactMap { $0.objCMethodNameFromLine }
     }
 

--- a/MachObfuscator/HeadersParsing/String+withoutComments.swift
+++ b/MachObfuscator/HeadersParsing/String+withoutComments.swift
@@ -9,7 +9,7 @@ extension String {
             .withoutOccurences(of: multilineCommentExpr)
     }
 
-    private func withoutOccurences(of regex: NSRegularExpression) -> String {
+    func withoutOccurences(of regex: NSRegularExpression) -> String {
         let fullRange = NSRange(location: 0, length: count)
         return regex
             .matches(in: self, options: [], range: fullRange)

--- a/MachObfuscatorTests/HeaderParsingTests/Samples/SystemLikeFramework.framework/Headers/NSDictionary.h
+++ b/MachObfuscatorTests/HeaderParsingTests/Samples/SystemLikeFramework.framework/Headers/NSDictionary.h
@@ -1,0 +1,7 @@
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSDictionary<K, V> (NSGenericFastEnumeraiton) <NSFastEnumeration>
+- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(K __unsafe_unretained _Nullable [_Nonnull])buffer count:(NSUInteger)len;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MachObfuscatorTests/HeaderParsingTests/Samples/SystemLikeFramework.framework/Headers/NSOrderedSet.h
+++ b/MachObfuscatorTests/HeaderParsingTests/Samples/SystemLikeFramework.framework/Headers/NSOrderedSet.h
@@ -1,0 +1,16 @@
+NS_ASSUME_NONNULL_BEGIN
+
+API_AVAILABLE(macos(10.7), ios(5.0), watchos(2.0), tvos(9.0))
+@interface NSOrderedSet<__covariant ObjectType> : NSObject <NSCopying, NSMutableCopying, NSSecureCoding, NSFastEnumeration>
+
+@property (readonly) NSUInteger count;
+- (ObjectType)objectAtIndex:(NSUInteger)idx;
+- (NSUInteger)indexOfObject:(ObjectType)object;
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithObjects:(const ObjectType _Nonnull [_Nullable])objects count:(NSUInteger)cnt NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithCoder:(NSCoder *)coder NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/MachObfuscatorTests/HeaderParsingTests/SimpleSourceSymbolsLoader_loadFromFrameworkURL_systemLikeFramework_Tests.swift
+++ b/MachObfuscatorTests/HeaderParsingTests/SimpleSourceSymbolsLoader_loadFromFrameworkURL_systemLikeFramework_Tests.swift
@@ -21,6 +21,8 @@ class SimpleSourceSymbolsLoader_loadFromFrameworkURL_systemLikeFramework_Tests: 
             "UIApplication",
             "UIUserNotificationSettings",
             "UIApplicationDelegate",
+            "NSDictionary",
+            "NSOrderedSet",
         ]
         XCTAssertEqual(symbols.classNames, expectedClassNames)
     }
@@ -35,6 +37,15 @@ class SimpleSourceSymbolsLoader_loadFromFrameworkURL_systemLikeFramework_Tests: 
             "applicationDidFinishLaunching:",
             "application:didFinishLaunchingWithOptions:",
             "application:handleActionWithIdentifier:forLocalNotification:completionHandler:",
+            // "NSDictionary.h"
+            "countByEnumeratingWithState:objects:count:",
+            // "NSOrderedSet.h"
+            "count",
+            "objectAtIndex:",
+            "indexOfObject:",
+            "init",
+            "initWithObjects:count:",
+            "initWithCoder:",
         ]
         XCTAssertEqual(symbols.selectors, expectedSelectors)
     }


### PR DESCRIPTION
Additional parameter annotations break selector detection in headers (which uses regexes). This was observed for nullable-related attributes: `__unsafe_unretained`, `_Nullable`, `_Nonnull` and other variations and arrays.
For example `countByEnumeratingWithState:objects:count:` was not detected properly.