### PR TITLE
Support for watchOS, tvOS and BitCode images

### DIFF
--- a/MachObfuscator/Commons/Paths.swift
+++ b/MachObfuscator/Commons/Paths.swift
@@ -41,6 +41,8 @@ enum Paths {
 
     static let macosFrameworksRoot: String = xcodeRoot + "/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
     static let iosFrameworksRoot: String = xcodeRoot + "/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"
+    static let watchosFrameworksRoot: String = xcodeRoot + "/Platforms/WatchOS.platform/Developer/SDKs/WatchOS.sdk"
+    static let tvosFrameworksRoot: String = xcodeRoot + "/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk"
 
     static let iosRuntimeRoot: String = {
         guard let iosRoot = possibleIosRuntimeRoots.first(where: FileManager.default.fileExists(atPath:)) else {

--- a/MachObfuscator/DependencyAnalysis/FileRepository+FrameworkLocationResolving.swift
+++ b/MachObfuscator/DependencyAnalysis/FileRepository+FrameworkLocationResolving.swift
@@ -44,6 +44,10 @@ private extension Mach.Platform {
             return Paths.iosFrameworksRoot.appending(path)
         case .macos:
             return Paths.macosFrameworksRoot.appending(path)
+        case .watchos:
+            return Paths.watchosFrameworksRoot.appending(path)
+        case .tvos:
+            return Paths.tvosFrameworksRoot.appending(path)
         }
     }
 }

--- a/MachObfuscator/Mach/Mach+Replacing.swift
+++ b/MachObfuscator/Mach/Mach+Replacing.swift
@@ -60,6 +60,9 @@ private extension Mach {
             for obfuscatedNode in obfuscatedTrie.flatNodes {
                 data.replaceBytes(inRange: obfuscatedNode.labelRange.intRange, withBytes: obfuscatedNode.label)
             }
+        } else if hasBitCode {
+            // LLVM-IR (Bitcode) images may not have export trie
+            LOGGER.info("Image '\(imageURL)' contains bitcode for \(cpu). Not obfuscating export trie.")
         } else {
             fatalError()
         }
@@ -88,6 +91,9 @@ private extension Mach {
                     data.replaceBytes(inRange: importEntry.symbolRange.intRange, withBytes: obfuscatedSymbol)
                 }
             }
+        } else if hasBitCode {
+            // LLVM-IR (Bitcode) images may not have import trie
+            LOGGER.info("Image '\(imageURL)' contains bitcode for \(cpu). Not obfuscating import stack.")
         } else {
             fatalError("Didn't resolve dylibs for '\(imageURL)'. Probably a bug.")
         }

--- a/MachObfuscator/Mach/Mach.swift
+++ b/MachObfuscator/Mach/Mach.swift
@@ -42,6 +42,8 @@ struct Mach {
     enum Platform {
         case macos
         case ios
+        case watchos
+        case tvos
     }
 
     var platform: Platform

--- a/MachObfuscator/SymbolsCollecting/ObfuscationSymbols+Building.swift
+++ b/MachObfuscator/SymbolsCollecting/ObfuscationSymbols+Building.swift
@@ -61,7 +61,9 @@ extension ObfuscationSymbols {
 
         let whitelistExportTriePerCpuIdPerURL: [URL: [CpuId: Trie]] =
             userSourcesPerPath.mapValues { symbolsSources in
-                [CpuId: Trie](symbolsSources.map { ($0.cpu.asCpuId, $0.exportedTrie!) },
+                // LLVM-IR (Bitcode) images may not have export trie
+                [CpuId: Trie](symbolsSources.filter { $0.exportedTrie != nil }
+                    .map { ($0.cpu.asCpuId, $0.exportedTrie!) },
                               uniquingKeysWith: { _, _ in fatalError("Duplicated cpuId") })
             }
 


### PR DESCRIPTION
Adds support for watchOS and tvOS binaries.
Adds support (i.e. Obfuscator does not crash) for Bitcode images - they currently cannot be obfuscated because they contain LLVM-IR, not usual metadata. 